### PR TITLE
Small changes on FormInputBase and TextInput

### DIFF
--- a/solute/epfl/components/form/form.py
+++ b/solute/epfl/components/form/form.py
@@ -6,7 +6,7 @@ from collections2 import OrderedDict as odict
 class FormInputBase(epflcomponentbase.ComponentBase):
     asset_spec = "solute.epfl.components:form/static"
 
-    compo_state = ['label', 'name', 'value', 'validation_error', 'readonly']
+    compo_state = ['label', 'name', 'value', 'validation_error', 'readonly', 'mandatory']
     js_parts = ["form/input_base.js"]
 
     js_name = ["input_base.js"]

--- a/solute/epfl/components/text_input/text_input.html
+++ b/solute/epfl/components/text_input/text_input.html
@@ -25,6 +25,9 @@
                value="{{ compo.value if compo.password == False and compo.value is not none else '' }}"
                data-initial-value="{{ compo.value if compo.password == False and compo.value is not none else '' }}"
                placeholder="{{ compo.placeholder if compo.placeholder is not none else '' }}"
+               {% if compo.typeahead == True %}
+                   autocomplete="off"
+               {% endif %}
                {% if compo.max_length is not none %}
                    maxlength="{{ compo.max_length }}"
                {% endif %} {% if compo.readonly is defined and compo.readonly %}disabled{% endif %}/>


### PR DESCRIPTION
- Added "mandatory" to FormInputBases compo_state
- Turn off autocomplete on TextInput if typeahead is true (to prevent overlapping typeahead and autocomplete dropdowns)