### PR TITLE
render compo.cid both as id and epflid attribute in container html

### DIFF
--- a/solute/epfl/templates/container/default_theme/container.html
+++ b/solute/epfl/templates/container/default_theme/container.html
@@ -1,6 +1,6 @@
 {% macro render() %}
     {% set compo = kwargs.compo %}
-    <div epflid="{{ compo.cid }}">
+    <div id="{{ compo.cid }}" epflid="{{ compo.cid }}">
         {{ caller() }}
     </div>
 {% endmacro %}


### PR DESCRIPTION
Use case: for different views, we want to adapt some component styles using css. To directly adress the correct components, we want to restrict our css selectors like
#view_name .epfl-button { ... }

for this, the top most component (typical a container, needs the cid to be rendered as html id attribute.
Otherwise, expensive lookups such as 
[epflid="view_name"] .epfl-button { ... }
are necessary.