### PR TITLE
Plain_html is now a FormInputComponent

### DIFF
--- a/solute/epfl/components/plain_html/plain_html.html
+++ b/solute/epfl/components/plain_html/plain_html.html
@@ -1,3 +1,3 @@
 <div epflid="{{ compo.cid }}">
-    {{ compo.html|safe }}
+    {{ compo.value|safe }}
 </div>

--- a/solute/epfl/components/plain_html/plain_html.py
+++ b/solute/epfl/components/plain_html/plain_html.py
@@ -9,20 +9,21 @@ class PlainHtml(FormInputBase):
 
     compo_state = ["html"]
 
-    html = ''  #: The HTML this component displays
+    value = ''  #: The HTML this component displays
     new_style_compo = True
     compo_js_name = 'PlainHtml'
+    validation_type = 'text'
 
-    def __init__(self, page, cid, html='', **extra_params):
+    def __init__(self, page, cid, value='', **extra_params):
         """ Simple component to display plain html
 
         Useage:
         .. code-block:: python
 
             PlainHtml(
-                html=u'<h1>Some nice heading</h1><span>With a span</span>'
+                value=u'<h1>Some nice heading</h1><span>With a span</span>'
             )
 
-        :param html: The html this component will display
+        :param value: The html this component will display
         """
-        super(PlainHtml, self).__init__(page, cid, html=html, **extra_params)
+        super(PlainHtml, self).__init__(page, cid, value=value, **extra_params)

--- a/solute/epfl/components/plain_html/plain_html.py
+++ b/solute/epfl/components/plain_html/plain_html.py
@@ -1,8 +1,8 @@
 # coding: utf-8
-from solute.epfl.core.epflcomponentbase import ComponentBase
+from solute.epfl.components.form.form import FormInputBase
 
 
-class PlainHtml(ComponentBase):
+class PlainHtml(FormInputBase):
     asset_spec = "solute.epfl.components:plain_html/static"
     template_name = "plain_html/plain_html.html"
     js_name = ["plain_html.js"]

--- a/solute/epfl/components/plain_html/plain_html.py
+++ b/solute/epfl/components/plain_html/plain_html.py
@@ -7,7 +7,7 @@ class PlainHtml(FormInputBase):
     template_name = "plain_html/plain_html.html"
     js_name = ["plain_html.js"]
 
-    compo_state = ["html"]
+    compo_state = ["value"]
 
     value = ''  #: The HTML this component displays
     new_style_compo = True


### PR DESCRIPTION
Changed plain html to being a FormInput Component instead of a BaseComponent to achive easier handling within forms