### PR TITLE
Typeahead fix js error on empty typeahed

### DIFF
--- a/solute/epfl/components/typeahead/static/typeahead.js
+++ b/solute/epfl/components/typeahead/static/typeahead.js
@@ -104,9 +104,11 @@ epfl.TypeAhead.prototype.after_response = function (data) {
         available_entries.eq(position).addClass('active');
         setTimeout(function () {
             var current_entry = available_entries.eq(position);
-            obj.list.scrollTop(
-                current_entry.offset().top - obj.list.offset().top + obj.list.scrollTop() - current_entry.outerHeight()
-            );
+            if(current_entry.length !== 0) {
+                obj.list.scrollTop(
+                    current_entry.offset().top - obj.list.offset().top + obj.list.scrollTop() - current_entry.outerHeight()
+                );
+            }
         }, 0);
     });
 


### PR DESCRIPTION
Fix a error which shows a js error if you push an arrow key and the list is empty